### PR TITLE
Remove dates from AIT event titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,25 +97,25 @@
       const events = [
         {
           date: "2025-03-03",
-          title: "AI Tinkerers Rome – March 3, 2025",
+          title: "AI Tinkerers Rome",
           url: "https://rome.aitinkerers.org/p/ai-tinkerers-rome-march-3-2025",
           location: "Rome",
         },
         {
           date: "2025-05-08",
-          title: "AI Tinkerers Milan – May 8, 2025",
+          title: "AI Tinkerers Milan",
           url: "https://milan.aitinkerers.org/p/ai-tinkerers-milan-may-8-2025",
           location: "Milan",
         },
         {
           date: "2025-05-30",
-          title: "AI Tinkerers Rome – May 30, 2025",
+          title: "AI Tinkerers Rome",
           url: "https://rome.aitinkerers.org/p/ai-tinkerers-rome-may-30-2025",
           location: "Rome",
         },
         {
           date: "2025-06-10",
-          title: "AI Tinkerers Milan – June 10, 2025",
+          title: "AI Tinkerers Milan",
           url: "https://milan.aitinkerers.org/p/ai-tinkerers-milan-june-10-2025-community-demos-networking",
           location: "Milan",
         },


### PR DESCRIPTION
## Summary
- remove date portion from AIT event names in index.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac10c3be08324a25b7fa8a93247e1