### PR TITLE
Add ML Dojo Rome event

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,12 @@
           location: "Milan",
         },
         {
+          date: "2025-07-13",
+          title: "ML Dojo #1",
+          url: "https://lu.ma/nugtfy0p?tk=69quCw",
+          location: "Rome",
+        },
+        {
           date: "2025-07-19",
           title: "AI Coder Dojo (IRL)",
           url: "https://lu.ma/d4tubldm",


### PR DESCRIPTION
## Summary
- add upcoming "ML Dojo #1" event for Rome on July 13th 2025

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e8d6c733c832480c2c70c15be50da