### PR TITLE
Add RSS of events + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Checkpoint Community Website
+
+This repository contains the static files used for the Checkpoint community website which is served via GitHub Pages.
+
+## Updating the events list
+
+Event information is stored in `events.json`. After modifying this file, run the Node.js script `generate-rss.js` to regenerate the RSS feed:
+
+```bash
+node generate-rss.js
+```
+
+This command produces `events.xml`, which is published to the site so visitors can subscribe to the events feed.
+
+The website itself reads from `events.json` at runtime to render the upcoming and past events on `index.html`.
+
+## Notes
+
+- `events.xml` must be committed after running the script so the RSS feed is available on the live site.
+- `generate-rss.js` is only needed locally and is excluded from the GitHub Pages output via the site configuration.
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+exclude:
+  - README.md
+  - generate-rss.js

--- a/events.json
+++ b/events.json
@@ -1,0 +1,38 @@
+[
+  {
+    "date": "2025-03-03",
+    "title": "AI Tinkerers Rome",
+    "url": "https://rome.aitinkerers.org/p/ai-tinkerers-rome-march-3-2025",
+    "location": "Rome"
+  },
+  {
+    "date": "2025-05-08",
+    "title": "AI Tinkerers Milan",
+    "url": "https://milan.aitinkerers.org/p/ai-tinkerers-milan-may-8-2025",
+    "location": "Milan"
+  },
+  {
+    "date": "2025-05-30",
+    "title": "AI Tinkerers Rome",
+    "url": "https://rome.aitinkerers.org/p/ai-tinkerers-rome-may-30-2025",
+    "location": "Rome"
+  },
+  {
+    "date": "2025-06-10",
+    "title": "AI Tinkerers Milan",
+    "url": "https://milan.aitinkerers.org/p/ai-tinkerers-milan-june-10-2025-community-demos-networking",
+    "location": "Milan"
+  },
+  {
+    "date": "2025-07-13",
+    "title": "ML Dojo #1",
+    "url": "https://lu.ma/nugtfy0p?tk=69quCw",
+    "location": "Rome"
+  },
+  {
+    "date": "2025-07-19",
+    "title": "AI Coder Dojo (IRL)",
+    "url": "https://lu.ma/d4tubldm",
+    "location": "Padua"
+  }
+]

--- a/events.xml
+++ b/events.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+  <title>Checkpoint Events</title>
+  <link>https://checkpoint-community.github.io/</link>
+  <description>Upcoming and past events</description>
+  <item>
+    <title>AI Tinkerers Rome</title>
+    <link>https://rome.aitinkerers.org/p/ai-tinkerers-rome-march-3-2025</link>
+    <description>Rome</description>
+    <pubDate>Mon, 03 Mar 2025 00:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>AI Tinkerers Milan</title>
+    <link>https://milan.aitinkerers.org/p/ai-tinkerers-milan-may-8-2025</link>
+    <description>Milan</description>
+    <pubDate>Thu, 08 May 2025 00:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>AI Tinkerers Rome</title>
+    <link>https://rome.aitinkerers.org/p/ai-tinkerers-rome-may-30-2025</link>
+    <description>Rome</description>
+    <pubDate>Fri, 30 May 2025 00:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>AI Tinkerers Milan</title>
+    <link>https://milan.aitinkerers.org/p/ai-tinkerers-milan-june-10-2025-community-demos-networking</link>
+    <description>Milan</description>
+    <pubDate>Tue, 10 Jun 2025 00:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>ML Dojo #1</title>
+    <link>https://lu.ma/nugtfy0p?tk=69quCw</link>
+    <description>Rome</description>
+    <pubDate>Sun, 13 Jul 2025 00:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>AI Coder Dojo (IRL)</title>
+    <link>https://lu.ma/d4tubldm</link>
+    <description>Padua</description>
+    <pubDate>Sat, 19 Jul 2025 00:00:00 GMT</pubDate>
+  </item>
+</channel>
+</rss>

--- a/generate-rss.js
+++ b/generate-rss.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const eventsPath = path.join(__dirname, 'events.json');
+const events = JSON.parse(fs.readFileSync(eventsPath, 'utf8'));
+
+const items = events.map(evt => {
+  const pubDate = new Date(evt.date).toUTCString();
+  return `  <item>\n    <title>${evt.title}</title>\n    <link>${evt.url}</link>\n    <description>${evt.location}</description>\n    <pubDate>${pubDate}</pubDate>\n  </item>`;
+}).join('\n');
+
+const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n  <title>Checkpoint Events</title>\n  <link>https://checkpoint-community.github.io/</link>\n  <description>Upcoming and past events</description>\n${items}\n</channel>\n</rss>\n`;
+
+fs.writeFileSync(path.join(__dirname, 'events.xml'), rss);

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       </section>
 
       <section id="upcoming-events">
-        <h2>Upcoming Events</h2>
+        <h2>Upcoming Events <a href="events.xml" style="font-size:0.8rem">RSS</a></h2>
         <ul id="upcoming-list">
           <!-- Filled dynamically -->
         </ul>
@@ -147,47 +147,9 @@
       </style>
 
     <script>
-      // Master list of events with locations
-      const events = [
-        {
-          date: "2025-03-03",
-          title: "AI Tinkerers Rome",
-          url: "https://rome.aitinkerers.org/p/ai-tinkerers-rome-march-3-2025",
-          location: "Rome",
-        },
-        {
-          date: "2025-05-08",
-          title: "AI Tinkerers Milan",
-          url: "https://milan.aitinkerers.org/p/ai-tinkerers-milan-may-8-2025",
-          location: "Milan",
-        },
-        {
-          date: "2025-05-30",
-          title: "AI Tinkerers Rome",
-          url: "https://rome.aitinkerers.org/p/ai-tinkerers-rome-may-30-2025",
-          location: "Rome",
-        },
-        {
-          date: "2025-06-10",
-          title: "AI Tinkerers Milan",
-          url: "https://milan.aitinkerers.org/p/ai-tinkerers-milan-june-10-2025-community-demos-networking",
-          location: "Milan",
-        },
-        {
-          date: "2025-07-13",
-          title: "ML Dojo #1",
-          url: "https://lu.ma/nugtfy0p?tk=69quCw",
-          location: "Rome",
-        },
-        {
-          date: "2025-07-19",
-          title: "AI Coder Dojo (IRL)",
-          url: "https://lu.ma/d4tubldm",
-          location: "Padua",
-        },
-      ];
-
-      document.addEventListener("DOMContentLoaded", () => {
+      document.addEventListener("DOMContentLoaded", async () => {
+        const res = await fetch('events.json');
+        const events = await res.json();
         const today = new Date();
         const upcomingList = document.getElementById("upcoming-list");
         const pastList = document.getElementById("past-list");


### PR DESCRIPTION
## Summary
- document how events are maintained
- exclude README and script from GitHub Pages output

## Testing
- `node generate-rss.js`


------
https://chatgpt.com/codex/tasks/task_e_68874950c55c8324955b9b7a1a2400e9